### PR TITLE
Bending over backwards for betty

### DIFF
--- a/holberton.h
+++ b/holberton.h
@@ -18,7 +18,7 @@ typedef struct functions
 
 /*main printing functions*/
 char *(*getfunction(char n))(va_list);
-int output(char *string, char *buffer, int buffer_size, int start, int mode);
+int output(char *buffer, int buffer_size, int start, int mode, ...);
 int _printf(const char *format, ...);
 int _strlen(char *string);
 


### PR DESCRIPTION
- Managed to reduce _printf() to under 40 lines by adding features to output()
- Retrofit output() to accept multiple chars at once reducing the need for multiple output() calls
- That also reqired updating the function prototpye as well as
changing the way output() knows when to copy a null byte (char_mode = -1)
- Added a check so write() only gets called twice if it absolutely needs to
- Catch the edge case where a string ends with '%'